### PR TITLE
[Feat]Update iOS Implementation with unused Android methods

### DIFF
--- a/android.js
+++ b/android.js
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style license that can be
 // found in the LICENSE file.
 
-import { NativeModules, Platform } from 'react-native';
+import { Platform } from 'react-native';
 import ReactNativeBlobUtil from './codegenSpecs/NativeBlobUtils';
 
 /**

--- a/class/ReactNativeBlobUtilFile.js
+++ b/class/ReactNativeBlobUtilFile.js
@@ -2,16 +2,4 @@
 // Use of this source code is governed by a MIT-style license that can be
 // found in the LICENSE file.
 
-
-import {
-  NativeModules,
-  DeviceEventEmitter,
-  NativeAppEventEmitter,
-} from 'react-native';
-
-const ReactNativeBlobUtil = NativeModules.ReactNativeBlobUtil;
-const emitter = DeviceEventEmitter;
-
-export default class ReactNativeBlobUtilFile {
-
-}
+export default class ReactNativeBlobUtilFile {}

--- a/class/ReactNativeBlobUtilReadStream.js
+++ b/class/ReactNativeBlobUtilReadStream.js
@@ -3,13 +3,12 @@
 // found in the LICENSE file.
 
 import {
-  NativeModules,
   DeviceEventEmitter,
   NativeAppEventEmitter,
 } from 'react-native';
 import UUID from '../utils/uuid';
 
-const ReactNativeBlobUtil = NativeModules.ReactNativeBlobUtil;
+import ReactNativeBlobUtil from "../codegenSpecs/NativeBlobUtils";
 const emitter = DeviceEventEmitter;
 
 export default class ReactNativeBlobUtilReadStream {

--- a/class/ReactNativeBlobUtilSession.js
+++ b/class/ReactNativeBlobUtilSession.js
@@ -3,12 +3,11 @@
 // found in the LICENSE file.
 
 import {
- NativeModules,
  DeviceEventEmitter,
  NativeAppEventEmitter,
 } from 'react-native';
 
-const ReactNativeBlobUtil = NativeModules.ReactNativeBlobUtil;
+import ReactNativeBlobUtil from "../codegenSpecs/NativeBlobUtils";
 
 let sessions = {};
 

--- a/class/ReactNativeBlobUtilWriteStream.js
+++ b/class/ReactNativeBlobUtilWriteStream.js
@@ -3,13 +3,11 @@
 // found in the LICENSE file.
 
 import {
- NativeModules,
  DeviceEventEmitter,
  NativeAppEventEmitter,
 } from 'react-native';
 
-const ReactNativeBlobUtil = NativeModules.ReactNativeBlobUtil;
-
+import ReactNativeBlobUtil from "../codegenSpecs/NativeBlobUtils";
 export default class ReactNativeBlobUtilWriteStream {
 
   id : string;

--- a/fetch.js
+++ b/fetch.js
@@ -2,7 +2,7 @@ import {ReactNativeBlobUtilConfig} from "./types";
 import URIUtil from "./utils/uri";
 import fs from "./fs";
 import getUUID from "./utils/uuid";
-import {DeviceEventEmitter, NativeModules} from "react-native";
+import {DeviceEventEmitter} from "react-native";
 import {FetchBlobResponse} from "./class/ReactNativeBlobUtilBlobResponse";
 import ReactNativeBlobUtil from "./codegenSpecs/NativeBlobUtils";
 

--- a/fs.js
+++ b/fs.js
@@ -4,7 +4,7 @@
 
 // import type {ReactNativeBlobUtilConfig, ReactNativeBlobUtilNative, ReactNativeBlobUtilStream} from './types'
 
-import {NativeModules, Platform} from 'react-native';
+import {Platform} from 'react-native';
 import ReactNativeBlobUtilSession from './class/ReactNativeBlobUtilSession';
 import ReactNativeBlobUtilWriteStream from './class/ReactNativeBlobUtilWriteStream';
 import ReactNativeBlobUtilReadStream from './class/ReactNativeBlobUtilReadStream';

--- a/ios.js
+++ b/ios.js
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style license that can be
 // found in the LICENSE file.
 
-import { NativeModules, Platform } from "react-native";
+import { Platform } from "react-native";
 import ReactNativeBlobUtil from "./codegenSpecs/NativeBlobUtils";
 
 /**

--- a/ios/ReactNativeBlobUtil/ReactNativeBlobUtil.h
+++ b/ios/ReactNativeBlobUtil/ReactNativeBlobUtil.h
@@ -28,6 +28,10 @@
 
 #import <UIKit/UIKit.h>
 
+#if RCT_NEW_ARCH_ENABLED
+#import <React-Codegen/ReactNativeBlobUtilSpec/ReactNativeBlobUtilSpec.h>
+#endif
+
 
 @interface ReactNativeBlobUtil : NSObject <RCTBridgeModule, UIDocumentInteractionControllerDelegate> {
 
@@ -41,5 +45,10 @@
 + (RCTEventDispatcher *)getRCTEventDispatcher;
 
 @end
+
+#if RCT_NEW_ARCH_ENABLED
+@interface ReactNativeBlobUtil () <NativeBlobUtilsSpec>
+@end
+#endif
 
 #endif /* ReactNativeBlobUtil_h */

--- a/ios/ReactNativeBlobUtil/ReactNativeBlobUtil.mm
+++ b/ios/ReactNativeBlobUtil/ReactNativeBlobUtil.mm
@@ -74,6 +74,10 @@ RCT_EXPORT_MODULE();
     return self;
 }
 
+- (NSDictionary *)getConstants {
+  return self.constantsToExport;
+}
+
 - (NSDictionary *)constantsToExport
 {
     return @{
@@ -86,6 +90,11 @@ RCT_EXPORT_MODULE();
              @"MusicDir" : [ReactNativeBlobUtilFS getMusicDir],
              @"PictureDir" : [ReactNativeBlobUtilFS getPictureDir],
              @"ApplicationSupportDir" : [ReactNativeBlobUtilFS getApplicationSupportDir],
+             // Android only. For the new architecture, we have a single spec for both platforms.
+             @"RingtoneDir": @"",
+             @"SDCardDir": @"",
+             @"SDCardApplicationDir": @"",
+             @"DCIMDir": @"",
              };
 }
 
@@ -853,7 +862,7 @@ RCT_EXPORT_METHOD(df:(RCTResponseSenderBlock)callback)
     [ReactNativeBlobUtilFS df:callback];
 }
 
-- (UIViewController *) documentInteractionControllerViewControllerForPreview: (UIDocumentInteractionController *) controller
+- (UIViewController *)documentInteractionControllerViewControllerForPreview: (UIDocumentInteractionController *) controller
 {
     UIWindow *window = [UIApplication sharedApplication].keyWindow;
     return window.rootViewController;
@@ -866,7 +875,88 @@ RCT_EXPORT_METHOD(emitExpiredEvent:(RCTResponseSenderBlock)callback)
     [ReactNativeBlobUtilNetwork emitExpiredTasks:eventDispatcherRef];
 }
 
+# pragma mark - Android Only methods
+// These methods are required because in the New Arch we have a single spec for both platforms
+- (void)actionViewIntent:(NSString *) path
+                    mime:(NSString *) mime
+            chooserTitle:(NSString *) chooserTitle
+                 resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject
+{
+    reject(@"ENOT_SUPPORTED", @"This method is not supported on iOS", nil);
+}
 
+- (void)addCompleteDownload:(NSDictionary *)config
+                    resolve:(RCTPromiseResolveBlock)resolve
+                     reject:(RCTPromiseRejectBlock)reject
+{
+    reject(@"ENOT_SUPPORTED", @"This method is not supported on iOS", nil);
+}
+
+- (void)copyToInternal:(NSString *)contentUri
+              destpath:(NSString *) destpath
+               resolve:(RCTPromiseResolveBlock)resolve
+                reject:(RCTPromiseRejectBlock)reject
+{
+    reject(@"ENOT_SUPPORTED", @"This method is not supported on iOS", nil);
+}
+- (void)copyToMediaStore:(NSDictionary *)filedata
+                      mt:(NSString *) mt
+                    path:(NSString *)
+                 resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject
+{
+    reject(@"ENOT_SUPPORTED", @"This method is not supported on iOS", nil);
+}
+
+- (void)createMediaFile:(NSDictionary *)filedata
+                    mt:(NSString *) mt
+               resolve:(RCTPromiseResolveBlock)resolve
+                reject:(RCTPromiseRejectBlock)reject
+{
+    reject(@"ENOT_SUPPORTED", @"This method is not supported on iOS", nil);
+}
+
+- (void)getBlob:(NSString *)contentUri
+       encoding:(NSString *)encoding
+        resolve:(RCTPromiseResolveBlock)resolve
+         reject:(RCTPromiseRejectBlock)reject
+{
+    reject(@"ENOT_SUPPORTED", @"This method is not supported on iOS", nil);
+}
+
+- (void)getContentIntent:(NSString *)mime
+                 resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject
+{
+    reject(@"ENOT_SUPPORTED", @"This method is not supported on iOS", nil);
+}
+- (void)getSDCardDir:(RCTPromiseResolveBlock)resolve
+              reject:(RCTPromiseRejectBlock)reject
+{
+    reject(@"ENOT_SUPPORTED", @"This method is not supported on iOS", nil);
+}
+- (void)getSDCardApplicationDir:(RCTPromiseResolveBlock)resolve
+              reject:(RCTPromiseRejectBlock)reject
+{
+    reject(@"ENOT_SUPPORTED", @"This method is not supported on iOS", nil);
+}
+- (void)scanFile:(NSArray *)pairs
+        callback:(RCTResponseSenderBlock)callback
+{
+    callback(@[@"Scan file method not supported in iOS"]);
+}
+- (void)writeToMediaFile:(NSString *)fileUri
+                    path:(NSString *)path
+           transformFile:(BOOL)transformFile
+                 resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject
+{
+    reject(@"ENOT_SUPPORTED", @"This method is not supported on iOS", nil);
+}
+
+
+# pragma mark - New Architecture
 #if RCT_NEW_ARCH_ENABLED
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
     (const facebook::react::ObjCTurboModule::InitParams &)params

--- a/mediacollection.js
+++ b/mediacollection.js
@@ -1,4 +1,3 @@
-import {NativeModules} from 'react-native';
 import type {ReactNativeBlobUtilNative, filedescriptor} from "types";
 import ReactNativeBlobUtil from "./codegenSpecs/NativeBlobUtils";
 


### PR DESCRIPTION
This PR adds to the iOS implementation all the methods that are also required by Android, because, currently, there is no way to specify two different sets of specifications.
The current setup crashes at startup due to some js imports.
